### PR TITLE
Improvement for DataConverter ReadJson

### DIFF
--- a/NetTopologySuite.IO.TopoJSON/Converters/DataConverter.cs
+++ b/NetTopologySuite.IO.TopoJSON/Converters/DataConverter.cs
@@ -44,6 +44,9 @@ namespace NetTopologySuite.IO.Converters
             double[][][] arcs = null;
             while (reader.Read())
             {
+                if (reader.TokenType == JsonToken.EndObject)
+                    continue;
+
                 if (reader.TokenType != JsonToken.PropertyName)
                     throw new ArgumentException("Expected a property but found " + reader.TokenType);
 
@@ -63,7 +66,6 @@ namespace NetTopologySuite.IO.Converters
                     case "arcs":
                         reader.Read(); // start array
                         arcs = serializer.Deserialize<double[][][]>(reader);
-                        reader.Read(); // end array
                         break;
 
                     default:


### PR DESCRIPTION
As arcs is not the last token in my Json, line 66 was reading into the next token. Isn't it better to handle the EndObject explicitly at the start of the while-loop?